### PR TITLE
The value of "kMDItemKind" depends on the language used in OS X. Should ...

### DIFF
--- a/bin/subl
+++ b/bin/subl
@@ -27,9 +27,9 @@ run ()     { log "% $@" && "$@"; }
 running () { ps -xo comm | fgrep -q "$pluginHost"; }
 execute () {
   if (( $# == 0 )); then
-    exec "$sublime" -a "$(slurpStdin)"
+    exec "$sublime" "$(slurpStdin)"
   else
-    exec "$sublime" -a "$@";
+    exec "$sublime" "$@";
   fi
 }
 


### PR DESCRIPTION
The value of "kMDItemKind" depends on the language used in OS X.
Should use "kMDItemContentType" instead of "kMDItemKind".
