### PR TITLE
Add a formula for sbt-extras

### DIFF
--- a/sbtx.rb
+++ b/sbtx.rb
@@ -1,0 +1,10 @@
+require 'formula'
+
+class Sbtx < Formula
+  head 'git://github.com/paulp/sbt-extras.git'
+
+  def install
+    bin.mkpath
+    mv "sbt", bin/"sbtx"
+  end
+end


### PR DESCRIPTION
This would be convenient to have for users of sbt-extras.

I'm submitting this for feedback, as I have little-to-no experience with
homebrew formulas, and there are several alternative ways to do this:

* Alternatively name the formula sbt
* Alternatively install the script as sbt-extras
* Alternatively take an option for toggling how to install the script

I'm open to suggestions and advice.